### PR TITLE
Fix doc links

### DIFF
--- a/custom_components/dominion_energy/manifest.json
+++ b/custom_components/dominion_energy/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": [],
   "config_flow": true,
   "dependencies": ["recorder"],
-  "documentation": "https://github.com/your-repo/ha-dominion-energy",
+  "documentation": "https://github.com/YeomansIII/ha-dominion-energy",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/your-repo/ha-dominion-energy/issues",
+  "issue_tracker": "https://github.com/YeomansIII/ha-dominion-energy/issues",
   "requirements": ["dompower==0.1.3"],
   "version": "1.1.6"
 }


### PR DESCRIPTION
The 'documentation' property is used in the ? in the config modal in home assistant, that's how I noticed this!

Also fixes issue #7 