### PR TITLE
Fix ruff CI failures

### DIFF
--- a/custom_components/dominion_energy/config_flow.py
+++ b/custom_components/dominion_energy/config_flow.py
@@ -2,27 +2,26 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+import voluptuous as vol
 from dompower import (
+    AccountInfo,
+    ApiError,
+    CannotConnectError,
     DompowerClient,
     GigyaAuthenticator,
-    InvalidCredentialsError,
-    TFAVerificationError,
-    TFAExpiredError,
     GigyaError,
-    CannotConnectError,
-    TokenExpiredError,
     InvalidAuthError,
-    ApiError,
-    TFATarget,
-    AccountInfo,
+    InvalidCredentialsError,
     MeterDevice,
+    TFAExpiredError,
+    TFATarget,
+    TFAVerificationError,
+    TokenExpiredError,
 )
-import voluptuous as vol
-
 from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
     ConfigEntry,

--- a/custom_components/dominion_energy/coordinator.py
+++ b/custom_components/dominion_energy/coordinator.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-import logging
 
 from dompower import (
     ApiError,
@@ -12,13 +12,13 @@ from dompower import (
     CannotConnectError,
     DompowerClient,
     GigyaAuthenticator,
+    GigyaError,
     IntervalUsageData,
     InvalidAuthError,
     InvalidCredentialsError,
     TFARequiredError,
     TokenExpiredError,
 )
-
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import (
     StatisticData,
@@ -67,7 +67,6 @@ from .const import (
     UPDATE_INTERVAL_MINUTES,
 )
 from .rates import VA_SCHEDULE_1, calculate_schedule1_interval_cost
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -200,7 +199,7 @@ class DominionEnergyCoordinator(DataUpdateCoordinator[DominionEnergyData]):
         except CannotConnectError as err:
             _LOGGER.warning("Auto-reauth failed - connection error: %s", err)
             return False
-        except Exception as err:
+        except GigyaError as err:
             _LOGGER.warning("Auto-reauth failed unexpectedly: %s", err)
             return False
 

--- a/custom_components/dominion_energy/rates.py
+++ b/custom_components/dominion_energy/rates.py
@@ -169,9 +169,8 @@ def calculate_consumption_tax(
         if position >= tier.upper_kwh:
             # Already past this tier
             continue
-        if position < tier.lower_kwh:
-            # Shouldn't happen with contiguous tiers, but handle gracefully
-            position = tier.lower_kwh
+        # Shouldn't happen with contiguous tiers, but handle gracefully
+        position = max(position, tier.lower_kwh)
 
         # How much of the remaining interval falls in this tier
         room_in_tier = tier.upper_kwh - position

--- a/custom_components/dominion_energy/sensor.py
+++ b/custom_components/dominion_energy/sensor.py
@@ -233,9 +233,11 @@ class DominionEnergySensor(CoordinatorEntity[DominionEnergyCoordinator], SensorE
         key = self.entity_description.key
 
         # Add data_date for daily and interval sensors
-        if key in ("daily_usage", "daily_cost", "latest_interval_usage"):
-            if self.coordinator.data.data_date:
-                attrs["data_date"] = self.coordinator.data.data_date.isoformat()
+        if (
+            key in ("daily_usage", "daily_cost", "latest_interval_usage")
+            and self.coordinator.data.data_date
+        ):
+            attrs["data_date"] = self.coordinator.data.data_date.isoformat()
 
         # Add date range for monthly sensors
         if key in ("monthly_usage", "monthly_cost"):


### PR DESCRIPTION
## Summary
Fixes the five Ruff findings that were failing Validate:

- I001 import sort in `config_flow.py` and `coordinator.py`
- BLE001: catch `GigyaError` instead of a bare `Exception` in auto-reauth
- PLR1730: `position = max(position, tier.lower_kwh)` in `rates.py`
- SIM102: collapse nested if in `sensor.py`

GitHub topics for HACS were added on the repo separately.

## Test plan
- [ ] Validate workflow Ruff Lint is green
- [ ] HACS Validation topics check is green